### PR TITLE
Add new button for "Contribute Now - It's on GitHub"

### DIFF
--- a/website/css/lapax.css
+++ b/website/css/lapax.css
@@ -26,6 +26,11 @@ a {
   padding-bottom: 25px;
   color: #fff;
 }
+
+.header .inline-button {
+  display: inline;
+}
+
 @media (max-width: 767px) {
   .header {
     min-height: 500px;
@@ -52,10 +57,10 @@ a {
   .header .navbar-default .navbar-toggle:hover {
     background: rgba(255, 255, 255, 0.2);
   }
-  .header .download-app {
+  .header .button-wrapper {
     padding-top: 30px;
   }
-  .header .download-app .btn-download {
+  .header .button-wrapper .btn-download {
     min-width: 250px;
     margin-bottom: 15px;
   }
@@ -154,7 +159,7 @@ a {
     padding: 0;
   }
 }
-.header .download-app {
+.header .button-wrapper {
   padding: 50px 0 0 0;
 }
 .header .arrow-down {

--- a/website/index.html
+++ b/website/index.html
@@ -73,10 +73,18 @@
                     </span>
                 </h2>
 
-                <div class="download-app">
-                    <a href="https://github.com/itidigitalbr/privacy-board-game#getting-started" class="btn btn-default btn-lg btn-download">
+                <div class="button-wrapper">
+                  <div class="inline-button">
+                      <a href="https://github.com/itidigitalbr/privacy-board-game#getting-started" class="btn btn-default btn-lg btn-download">
                         Play Now - <span>It’s Open</span>
                       </a>
+                  </div>
+
+                  <div class="inline-button">
+                      <a href="https://github.com/itidigitalbr/privacy-board-game" class="btn btn-default btn-lg btn-download">
+                        Contribute Now - <span>It’s on GitHub</span>
+                      </a>
+                  </div>
                 </div>
 
                 <div>


### PR DESCRIPTION
***Why is this change necessary?***
We need to add a button next to the "Play Now - It's open" button that will have the text "Contribute Now - It's on GitHub" that points to https://github.com/itidigitalbr/privacy-board-game

***How does this accomplish the change?***
- Added required html
- Updated the css class names to be more generic so that they match both the buttons
- Added required css to align the buttons next to each other

This resolves #57 

## Screenshots by screen sizes

### Large
<img width="1161" alt="screen shot 2017-10-17 at 11 37 16 pm" src="https://user-images.githubusercontent.com/3662050/31700049-b8a7b450-b394-11e7-9651-470b3ecaaae9.png">

### Medium
<img width="989" alt="screen shot 2017-10-17 at 11 37 44 pm" src="https://user-images.githubusercontent.com/3662050/31700051-b8bca770-b394-11e7-8bfc-a9e6532a5dab.png">

### Small
<img width="510" alt="screen shot 2017-10-17 at 11 37 28 pm" src="https://user-images.githubusercontent.com/3662050/31700050-b8b23a10-b394-11e7-9e6e-893f01e4aa75.png">