### PR TITLE
Fixed "text-shadow"

### DIFF
--- a/website/css/lapax.css
+++ b/website/css/lapax.css
@@ -157,7 +157,7 @@ margin-top: 19px;
   font-size: 90px;
   font-weight: 900;
   letter-spacing: 35px;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+  text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.2);
 }
 
 @media (max-width: 767px) {
@@ -189,7 +189,7 @@ top: 50%;
   margin: 0 auto;
   line-height: 1.2;
   padding: 20px 0 0 0;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+  text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.2);
 }
 @media (max-width: 767px) {
   .header .intro {


### PR DESCRIPTION
The "text-shadow" is used to add shadow to text.
Here in 
```
text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.2);
```
It means that, the text has shadow of 1px in x(horizontal) and 1px in y(vertical) and has 1px blur-radius and rgb is for the color, 0 is for pure back and 255 is for white. and a is for alpha channel,where 0.0 is fully transparent and 1.0 fully opaque.